### PR TITLE
Allow explicit mongodb connection string

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@
 
 const mongooseConn = function(mongoose,Promise){
     const getProductionURI = function(){
+        if (process.env.STORE_MONGODB_CONNECTION_STRING)
+            return process.env.STORE_MONGODB_CONNECTION_STRING;
+        
         let connectionString = 'mongodb://';
         let database = process.env.ENVIRONMENT === 'test' ? process.env.STORE_MONGODB_DATABASE_TEST : process.env.STORE_MONGODB_DATABASE;
 


### PR DESCRIPTION
Add support for env variable STORE_MONGODB_CONNECTION_STRING to enable using advanced features like replica sets and support more flexible deployment scenarios.